### PR TITLE
Fix #5:  Prevent `t.querySelectorAll is not a function` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Prevent `addedNode.querySelectorAll is not a function` error (#13)
+
 ## [0.2.0] - 2024-01-04
 
 ### Fixed
--  Fixed left/right arrow key behavior in RTL content (#9)
+- Fixed left/right arrow key behavior in RTL content (#9)
 
 ## [0.1.0] - 2023-08-26
 
 ### Added
--  Add style to fix bidi in the default theme (#4)
+- Add style to fix bidi in the default theme (#4)
 
 ## [0.0.2] - 2023-08-25
 

--- a/index.js
+++ b/index.js
@@ -275,6 +275,7 @@ const applyBidi = () => {
       if (mutation.type !== 'childList') return;
 
       mutation.addedNodes.forEach((addedNode) => {
+        if (addedNode.nodeType === 3) return;
         if (addedNode.classList?.contains('ls-block')) setDirAuto(addedNode);
 
         const subLsBlocks = addedNode.querySelectorAll(cssSelector);

--- a/index.js
+++ b/index.js
@@ -275,7 +275,8 @@ const applyBidi = () => {
       if (mutation.type !== 'childList') return;
 
       mutation.addedNodes.forEach((addedNode) => {
-        if (addedNode.nodeType === 3) return;
+        if (addedNode.nodeType !== Node.ELEMENT_NODE) return;
+
         if (addedNode.classList?.contains('ls-block')) setDirAuto(addedNode);
 
         const subLsBlocks = addedNode.querySelectorAll(cssSelector);


### PR DESCRIPTION
Prevent `t.querySelectorAll is not a function` error

## PR Checklist
<!-- Check items as done and wrap them in `~` if they are not relevant to your changes -->

- [x] Update Changelog <!-- Based on https://keepachangelog.com -->

closes #5 